### PR TITLE
Respect ssh_options[:keys]

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'rake/testtask'
 
 spec = Gem::Specification.new do |s|
   s.name             = 'capistrano_rsync_with_remote_cache'
-  s.version          = '2.4.0'
+  s.version          = '2.4.1'
   s.has_rdoc         = true
   s.extra_rdoc_files = %w(README.rdoc)
   s.rdoc_options     = %w(--main README.rdoc)

--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -44,7 +44,9 @@ module Capistrano
         end
         
         def rsync_command_for(server)
-          "rsync #{rsync_options} --rsh='ssh -p #{ssh_port(server)}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
+          ssh_options_string = "-p #{ssh_port(server)}"
+          ssh_options_string << " -i #{ssh_options[:keys]}" if ssh_options[:keys]
+          "rsync #{rsync_options} --rsh='ssh #{ssh_options_string}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
         end
         
         def mark_local_cache


### PR DESCRIPTION
When deploying to ec2, it's essential to use a identity file with ssh, so we made a simple hack to take its location from ssh_options. We briefly tried getting the tests to run, but got stuck on dependencies, so apologies for not having tests.
