### PR TITLE
path offset specification

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'rake/testtask'
 
 spec = Gem::Specification.new do |s|
   s.name             = 'capistrano_rsync_with_remote_cache'
-  s.version          = '2.4.0'
+  s.version          = '2.4.0.1'
   s.has_rdoc         = true
   s.extra_rdoc_files = %w(README.rdoc)
   s.rdoc_options     = %w(--main README.rdoc)

--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -44,7 +44,7 @@ module Capistrano
         end
         
         def rsync_command_for(server)
-          "rsync #{rsync_options} --rsh='ssh -p #{ssh_port(server)}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
+          "rsync #{rsync_options} --rsh='ssh -p #{ssh_port(server)}' #{local_cache_path_with_offset} #{rsync_host(server)}:#{repository_cache_path}/"
         end
         
         def mark_local_cache
@@ -57,6 +57,10 @@ module Capistrano
         
         def local_cache_path
           File.expand_path(local_cache)
+        end
+
+        def local_cache_path_with_offset
+          File.join(local_cache_path, configuration[:rsync_with_remote_cache_path_offset].to_s, '')
         end
         
         def repository_cache_path


### PR DESCRIPTION
Hi there,

I've made a little addition:

[master b758ee3] Allow a path offset to be specified so that you can only deploy part of the source tree to the remote server

Don't know if this will be useful for general inclusion in your strategy, but I'm using it here and it's working great.  There's no other way I've found to only deploy the 'public' directory of a Rails app to a front end server.  Am using this with capistrano_multiple_deployment_strategy.

Cheers,
Roger
