### PR TITLE
only specify a -p option to ssh when the port is explicitly set

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -44,7 +44,12 @@ module Capistrano
         end
         
         def rsync_command_for(server)
-          "rsync #{rsync_options} --rsh='ssh -p #{ssh_port(server)}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
+          "rsync #{rsync_options} --rsh='ssh#{ssh_port_option(server)}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
+        end
+        
+        def ssh_port_option(server)
+          port = ssh_port(server)
+          port ? " -p #{port}" : ""
         end
         
         def mark_local_cache
@@ -52,7 +57,7 @@ module Capistrano
         end
         
         def ssh_port(server)
-          server.port || ssh_options[:port] || 22
+          server.port || ssh_options[:port] || nil
         end
         
         def local_cache_path

--- a/test/capistrano_rsync_with_remote_cache_test.rb
+++ b/test/capistrano_rsync_with_remote_cache_test.rb
@@ -101,10 +101,16 @@ class CapistranoRsyncWithRemoteCacheTest < Test::Unit::TestCase
       @strategy.remove_cache_if_repository_url_changed
     end
     
-    should "know the default SSH port" do
+    should "not have a default SSH port" do
       @strategy.stubs(:ssh_options).with().returns({})
       server = stub(:port => nil)
-      @strategy.ssh_port(server).should == 22
+      @strategy.ssh_port(server).should == nil
+    end
+    
+    should "not specify a 'ssh -p' option by default" do
+      @strategy.stubs(:ssh_options).with().returns({})
+      server = stub(:port => nil)
+      @strategy.ssh_port_option(server).should == ''
     end
     
     should "be able to override the default SSH port" do
@@ -118,6 +124,13 @@ class CapistranoRsyncWithRemoteCacheTest < Test::Unit::TestCase
       server = stub(:port => 123)
       @strategy.ssh_port(server).should == 123
     end
+    
+    should "know the ssh port option when a SSH port is specified" do
+      @strategy.stubs(:ssh_options).with().returns({:port => 95})
+      server = stub(:port => nil)
+      @strategy.ssh_port_option(server).should == ' -p 95'
+    end
+      
 
     should "know the default repository cache" do
       @strategy.repository_cache.should == 'cached-copy'


### PR DESCRIPTION
capistrano_rsync_with_remote_cache always adds the option '-p <port>' to the rsync rsh option. When there is no port in any capistrano setting, the default port 22 is used. This does not work in the case that there is no port in capistrano settings or server definition, but in a host entry in .ssh/config, as the '-p 22' option overwrites the config file.
Capistrano SSH calls don't have this problem as Net::SSH reads and applies .ssh/config in its ruby code.

This pull request changes the rsync call to only include a -p option to ssh when the port is explicitly set in capistrano. This causes rsync to honor .ssh/config entries automatically.
