### PR TITLE
Ignore .hg directory and files by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /coverage/
 *.gem
 .yardoc
+.DS_Store
+

--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -19,7 +19,7 @@ module Capistrano
           :bzr        => "bzr info | grep parent | sed \'s/^.*parent branch: //\'"
         }
         
-        default_attribute :rsync_options, '-az --delete --exclude=.hg*'
+        default_attribute :rsync_options, '-az --delete --exclude=.hg* --exclude=.git* --exclude=.svn*'
         default_attribute :local_cache, '.rsync_cache'
         default_attribute :repository_cache, 'cached-copy'
 

--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -19,7 +19,7 @@ module Capistrano
           :bzr        => "bzr info | grep parent | sed \'s/^.*parent branch: //\'"
         }
         
-        default_attribute :rsync_options, '-az --delete'
+        default_attribute :rsync_options, '-az --delete --exclude=.hg*'
         default_attribute :local_cache, '.rsync_cache'
         default_attribute :repository_cache, 'cached-copy'
 


### PR DESCRIPTION
A better default rsync setting, would be to exclude the .hg directory and files. No need to send them over to production servers
