### PR TITLE
Allow additional ssh options

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -44,11 +44,19 @@ module Capistrano
         end
         
         def rsync_command_for(server)
-          "rsync #{rsync_options} --rsh='ssh -p #{ssh_port(server)}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
+          "rsync #{rsync_options} --rsh='#{remote_shell_command}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
         end
         
         def mark_local_cache
           File.open(File.join(local_cache_path, 'REVISION'), 'w') {|f| f << revision }
+        end
+        
+        def remote_shell_command
+          cmd = "ssh -p #{ssh_port(server)}"
+          if ssh_options.has_key?(:config)
+            cmd << %Q{ -F "#{ssh_option[:config]}"}
+          end
+          cmd
         end
         
         def ssh_port(server)

--- a/test/capistrano_rsync_with_remote_cache_test.rb
+++ b/test/capistrano_rsync_with_remote_cache_test.rb
@@ -240,7 +240,7 @@ class CapistranoRsyncWithRemoteCacheTest < Test::Unit::TestCase
       
       @strategy.stubs(
         :rsync_options         => 'rsync_options', 
-        :ssh_port              => 'ssh_port',
+        :remote_shell_command  => 'ssh -p ssh_port',
         :local_cache_path      => 'local_cache_path',
         :repository_cache_path => 'repository_cache_path'
       )


### PR DESCRIPTION
Hi,

these changes allow an ssh config file to be passed to ssh. This is useful if special options are needed to connect to a particular host. Please consider merging.

Thanks

David Heath
