### PR TITLE
Add support for rsync --exclude to speed up deployment

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -46,7 +46,9 @@ module Capistrano
         end
         
         def rsync_command_for(server)
-          "rsync #{rsync_options} --rsh='ssh -p #{ssh_port(server)}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
+          sync_exclude = configuration[:sync_exclude] || []
+          exclusions = sync_exclude.map { |e| "--exclude=\"#{e}\"" }.join(' ')
+          "rsync #{rsync_options} #{exclusions} --rsh='ssh -p #{ssh_port(server)}' #{local_cache_path}/ #{rsync_host(server)}:#{repository_cache_path}/"
         end
         
         def mark_local_cache

--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -40,7 +40,9 @@ module Capistrano
         end
         
         def copy_remote_cache
-          run("rsync -a --delete #{repository_cache_path}/ #{configuration[:release_path]}/")
+          copy_exclude = configuration[:copy_exclude] || []
+          exclusions = copy_exclude.map { |e| "--exclude=\"#{e}\"" }.join(' ')
+          run("rsync -a --delete #{exclusions} #{repository_cache_path}/ #{configuration[:release_path]}/")
         end
         
         def rsync_command_for(server)

--- a/test/capistrano_rsync_with_remote_cache_test.rb
+++ b/test/capistrano_rsync_with_remote_cache_test.rb
@@ -268,8 +268,20 @@ class CapistranoRsyncWithRemoteCacheTest < Test::Unit::TestCase
         :repository_cache_path => 'repository_cache_path',
         :configuration         => {:release_path => 'release_path'}
       )
-      
-      command = "rsync -a --delete repository_cache_path/ release_path/"
+
+      command = "rsync -a --delete  repository_cache_path/ release_path/"
+      @strategy.expects(:run).with(command)
+
+      @strategy.copy_remote_cache
+    end
+
+    should "be able copy the remote cache into place with exclusions" do
+      @strategy.stubs(
+        :repository_cache_path => 'repository_cache_path',
+        :configuration         => {:release_path => 'release_path', :copy_exclude => ['.git', 'data']}
+      )
+
+      command = 'rsync -a --delete --exclude=".git" --exclude="data" repository_cache_path/ release_path/'
       @strategy.expects(:run).with(command)
       
       @strategy.copy_remote_cache

--- a/test/capistrano_rsync_with_remote_cache_test.rb
+++ b/test/capistrano_rsync_with_remote_cache_test.rb
@@ -242,11 +242,12 @@ class CapistranoRsyncWithRemoteCacheTest < Test::Unit::TestCase
         :rsync_options         => 'rsync_options', 
         :ssh_port              => 'ssh_port',
         :local_cache_path      => 'local_cache_path',
-        :repository_cache_path => 'repository_cache_path'
+        :repository_cache_path => 'repository_cache_path',
+        :configuration         => { sync_exclude: [ '.git', 'data' ]  }
       )
       
-      expected = "rsync rsync_options --rsh='ssh -p ssh_port' local_cache_path/ rsync_host:repository_cache_path/"
       
+      expected = %q(rsync rsync_options --exclude=".git" --exclude="data" --rsh='ssh -p ssh_port' local_cache_path/ rsync_host:repository_cache_path/)
       @strategy.rsync_command_for(server).should == expected
     end
     


### PR DESCRIPTION
This simply adds a `copy_exclude` configuration option that is converted to rsync `--exclude` parameters.

Similar in implementation to [remote_cache](https://github.com/capistrano/capistrano/blob/master/lib/capistrano/recipes/deploy/strategy/remote_cache.rb).
