### PR TITLE
[BUG] Touch release path after deploy

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -40,7 +40,7 @@ module Capistrano
         end
         
         def copy_remote_cache
-          run("rsync -a --delete #{repository_cache_path}/ #{configuration[:release_path]}/")
+          run("rsync -a --delete #{repository_cache_path}/ #{configuration[:release_path]}/ && touch #{configuration[:release_path]}/")
         end
         
         def rsync_command_for(server)
@@ -100,6 +100,7 @@ module Capistrano
             check.local.command(source.command)
             check.local.command('rsync')
             check.remote.command('rsync')
+            check.remote.command('touch')
           end
         end
 


### PR DESCRIPTION
I've found a major bug while using this gem.

When deploying without `-t` in `rsync_options` all the modification time of the release directories are equals, since the rsync from the cache to the production use `-a` option.

The problem arise when running `cap deploy:cleanup`: since all directory have the same timestamp, **the directory to delete are randomly selected**, not the oldest as it should be. In my scenario, this completely destroy the production.

A simple touch after deploy solves the problem.

I'm sorry I cannot create a test case, but I'm a Ruby newbie and Rake is complaining about deprecated libraries...
