### PR TITLE
retry checkout if it fails

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/rsync_with_remote_cache.rb
@@ -30,7 +30,10 @@ module Capistrano
         end
 
         def update_local_cache
-          system(command)
+          unless system(command)
+            system("rm -rf #{local_cache_path}")
+            system(command)
+          end
           mark_local_cache
         end
 


### PR DESCRIPTION
Often the deploy fails because the exact commit in the new deployed branch is not present as the child of the branch in local cache. 

```
executing locally: cd /path/to/proj/.rsync_cache && git fetch -q origin && git fetch --tags -q origin && git reset -q --hard 5875782837e6ba2892903811c2c183fcd6749442 && git clean -q -d -x -f
fatal: Could not parse object '5875782837e6ba2892903811c2c183fcd6749442'.
```
Currently it continues like everything's fine but it needs to either stop or retry after deleting the local cache.